### PR TITLE
Fix: Correct API key loading from environment variables (closes #10)

### DIFF
--- a/webserver/configs/settings.py
+++ b/webserver/configs/settings.py
@@ -55,8 +55,12 @@ def load_settings_from_yaml(file_path: str) -> Settings:
     load_dotenv()
     llm_params = LLMParameters(**llm_config)
     llm_params.api_key = os.environ.get("GRAPHRAG_API_KEY", llm_config['api_key'])
+    if llm_params.api_key == "<API_KEY>":
+        llm_params.api_key = llm_config['api_key']
     text_embedding = TextEmbeddingConfig(**embeddings_config)
     text_embedding.llm.api_key = os.environ.get("GRAPHRAG_API_KEY", embeddings_config['llm']['api_key'])
+    if text_embedding.llm.api_key == "<API_KEY>":
+        text_embedding.llm.api_key = embeddings_config['llm']['api_key']
 
     return Settings(
         llm=llm_params,

--- a/webserver/configs/settings.py
+++ b/webserver/configs/settings.py
@@ -57,8 +57,12 @@ def load_settings_from_yaml(file_path: str) -> Settings:
     llm_params.api_key = os.environ.get("GRAPHRAG_API_KEY", llm_config['api_key'])
     if llm_params.api_key == "<API_KEY>":
         llm_params.api_key = llm_config['api_key']
+    if not llm_params.api_key:
+        raise ValueError("llm_params.api_key is empty. Please provide a valid API key.")
     text_embedding = TextEmbeddingConfig(**embeddings_config)
     text_embedding.llm.api_key = os.environ.get("GRAPHRAG_API_KEY", embeddings_config['llm']['api_key'])
+    if not text_embedding.llm.api_key:
+        raise ValueError("text_embedding.llm.api_key is empty. Please provide a valid API key.")
     if text_embedding.llm.api_key == "<API_KEY>":
         text_embedding.llm.api_key = embeddings_config['llm']['api_key']
 


### PR DESCRIPTION
<!--
Thanks for contributing to GraphRAG!

Please do not make *Draft* pull requests, as they still notify anyone watching the repo.

Create a pull request when it is ready for review and feedback.

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), the motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

## Description

This pull request addresses an issue where the `llm_params.api_key` and `text_embedding.llm.api_key` variables were being incorrectly set to the literal string `"<API_KEY>"` due to a lack of proper validation after reading the environment variable `GRAPHRAG_API_KEY`. The issue was identified in lines 56 and 58 of the code. The proposed fix includes adding conditional checks to ensure that if the API keys are set to `"<API_KEY>"`, they are replaced with the correct values from the respective configuration files (`llm_config['api_key']` and `embeddings_config['llm']['api_key']`).

## Related Issues

This pull request addresses issue [#10](https://github.com/KylinMountain/graphrag-server/issues/10).

## Proposed Changes

- Added a conditional check for `llm_params.api_key` to replace `"<API_KEY>"` with the correct value from `llm_config['api_key']`.
- Added a conditional check for `text_embedding.llm.api_key` to replace `"<API_KEY>"` with the correct value from `embeddings_config['llm']['api_key']`.
- Added a check to verify if `llm_params.api_key` or `text_embedding.llm.api_key` is empty after loading. If either is empty, a ValueError is raised to notify the user.

## Checklist

- [x] I have tested these changes locally.
- [x] I have reviewed the code changes.
- [ ] I have updated the documentation (if necessary).
- [ ] I have added appropriate unit tests (if applicable).

## Additional Notes

No additional notes at this time.
